### PR TITLE
🛡️ - [security] added the nova:api middleware on api routes registration

### DIFF
--- a/src/ToolServiceProvider.php
+++ b/src/ToolServiceProvider.php
@@ -45,7 +45,7 @@ class ToolServiceProvider extends ServiceProvider
         Nova::router(['nova', Authenticate::class, Authorize::class], 'nova-logs')
             ->group(__DIR__ . '/../routes/inertia.php');
 
-        Route::middleware(['nova', Authorize::class])
+        Route::middleware(['nova', 'nova:api', Authorize::class])
             ->prefix('nova-vendor/php-junior/nova-log-viewer')
             ->group(__DIR__ . '/../routes/api.php');
     }


### PR DESCRIPTION
## The issue:

API routes are open to everyone. So everyone can download the log files and see it.

## Explanation:

Default behavior on Nova tools is that routes inside api are not protected. Please find the related discussion in nova-issues.
The solution is to add the middleware `nova:api`.

https://github.com/laravel/nova-issues/discussions/5496